### PR TITLE
Fix link in utils.py

### DIFF
--- a/ModalityConverter/ModalityConverterLib/UI/utils.py
+++ b/ModalityConverter/ModalityConverterLib/UI/utils.py
@@ -31,7 +31,7 @@ SlicerModalityConverter is an open-source 3D Slicer extension designed for medic
 <b>More info</b>
 <ul>
     <li>View the source code on GitHub: <a href="https://github.com/ciroraggio/SlicerModalityConverter">https://github.com/ciroraggio/SlicerModalityConverter</a></li>
-    <li><a href="https://github.com/ciroraggio/SlicerModalityConverter/blob/main/README.md#-how-to-integrate-a-custom-model-into-the-ModalityConverter-module">How to integrate your models in ModalityConverter</a></li>
+    <li><a href="https://github.com/ciroraggio/SlicerModalityConverter/blob/main/README.md#how-to-integrate-a-custom-model">How to integrate your models in ModalityConverter</a></li>
 </ul>
 <br/>
 <b>How to cite</b>


### PR DESCRIPTION
New link is https://github.com/ciroraggio/SlicerModalityConverter/blob/main/README.md#how-to-integrate-a-custom-model