### PR TITLE
feat: Add Unet2PixT1T2 model

### DIFF
--- a/ModalityConverter/ModalityConverterLib/ModelsImpl/Unet2PixT1T2Model.py
+++ b/ModalityConverter/ModalityConverterLib/ModelsImpl/Unet2PixT1T2Model.py
@@ -1,0 +1,92 @@
+import numpy as np
+import onnxruntime as ort
+import scipy.ndimage
+from ModalityConverterLib.ModelBase import BaseModel, register_model
+
+
+@register_model("unet2pix_t1_t2")
+class Unet2PixT1T2Model(BaseModel):
+    def __init__(self, modelKey: str, device: str = "cpu"):
+        super().__init__(modelKey, device)
+        self.ort_session = None
+
+    def _loadModelFromPath(self, modelPath):
+        providers = ['CPUExecutionProvider']
+        if self.device == 'cuda':
+            providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
+
+        self.ort_session = ort.InferenceSession(modelPath, providers=providers)
+        return self.ort_session
+
+    def _percnorm(self, arr, lperc=5, uperc=99.5):
+        lowerbound = np.percentile(arr, lperc)
+        upperbound = np.percentile(arr, uperc)
+        np.clip(arr, lowerbound, upperbound, out=arr)
+        return arr
+
+    def _normalize(self, img):
+        img_min = img.min()
+        img_max = img.max()
+        if (img_max - img_min) > 1e-8:
+            return (img - img_min) / (img_max - img_min)
+        return img - img_min
+
+    def _resize_slice(self, slice_2d, target_h, target_w):
+        """
+        Resizes slice to target dimensions using interpolation.
+        Required because the model expects fixed input size (224x192).
+        """
+        h, w = slice_2d.shape
+        zoom_factors = (target_h / h, target_w / w)
+        # Order 1 = bilinear interpolation
+        return scipy.ndimage.zoom(slice_2d, zoom_factors, order=1)
+
+    def runInference(self, inputVolume, outputVolume, inputMask=None, showAllFiles=True):
+        """
+        Logic:
+        1. Copy full input (T1) to output.
+        2. Extract ONLY the central axial slice.
+        3. Resize to 224x192 -> Inference (Generate T2) -> Resize back.
+        4. Replace only the central slice in the output volume with the synthetic T2.
+        """
+
+        outputVolume[:] = inputVolume[:]
+
+        # Original dimensions: [Depth, Height, Width]
+        d_orig, h_orig, w_orig = inputVolume.shape
+        center_idx = d_orig // 2
+
+        # Extract slice (copy to ensure float32 processing)
+        slice_orig = inputVolume[center_idx, :, :].copy().astype(np.float32)
+
+        # Preprocessing
+        slice_proc = self._percnorm(slice_orig)
+        slice_proc = self._normalize(slice_proc)
+
+        # Resize for model (Target: H=224, W=192)
+        target_h, target_w = 224, 192
+        slice_input_model = self._resize_slice(slice_proc, target_h, target_w)
+
+        # Prepare ONNX tensor [1, 1, 224, 192]
+        input_tensor = slice_input_model[np.newaxis, np.newaxis, :, :]
+
+        # Get ONNX input names
+        input_name = self.ort_session.get_inputs()[0].name
+        timestep_name = self.ort_session.get_inputs()[1].name
+        timestep_input = np.zeros((1,), dtype=np.float32)
+
+        # Inference
+        ort_inputs = {
+            input_name: input_tensor,
+            timestep_name: timestep_input
+        }
+        result = self.ort_session.run(None, ort_inputs)
+
+        # Model output is [1, 1, 224, 192] -> squeeze to [224, 192]
+        generated_slice_small = result[0].squeeze()
+
+        # Post-processing: Resize back to patient original dimensions
+        generated_slice_final = self._resize_slice(generated_slice_small, h_orig, w_orig)
+
+        # Insert generated T2 slice back into volume
+        outputVolume[center_idx, :, :] = generated_slice_final

--- a/ModalityConverter/Resources/Models/metadata.json
+++ b/ModalityConverter/Resources/Models/metadata.json
@@ -16,5 +16,11 @@
         "display_name": "[Brain] FedSynthCT MRI-T1w Spadea Model",
         "description": "This model was trained using FedSynthCT-Brain, a federated learning framework for brain MRI-to-CT translation.<br><b>Input</b>: T1-weighted MRI scans.<br><b>Preprocess</b>: N4ITK Bias Field Correction, Crop/Pad/Resize.<br><b>Output</b>: Synthetic CT volume [256x256x256].<br><b>How to cite:</b><br>If you use this model, please cite:<br><cite>C.B. Raggio et al, FedSynthCT-Brain: A federated learning framework for multi-institutional brain MRI-to-CT synthesis, Computers in Biology and Medicine, Volume 192, Part A, 2025, 110160, ISSN 0010-4825, https://doi.org/10.1016/j.compbiomed.2025.110160.</cite>",
         "module_name": "FedSynthBrainSpadeaModel"
-    }
+    },
+    "unet2pix_t1_t2": {
+    "url": "https://github.com/AndreaMoschetto/medical-I2I-benchmark/raw/refs/heads/main/models/onnx/Unet2PixT1T2.onnx",
+    "display_name": "[Brain] MRI T1-to-T2 (Unet2Pix Center-Slice)",
+    "description": "Generates a synthetic T2-weighted MRI slice ONLY for the central axial slice of the input volume.<br><b>Input</b>: Brain MRI T1w<br><b>Output</b>: Input volume with the central slice replaced by the synthetic T2w.<br><b>Note</b>: Input is resized to 224x192 for inference and scaled back.<br><b>Citation:</b><br><cite>Moschetto et al., Medical I2I Benchmark.</cite>",
+    "module_name": "Unet2PixT1T2Model"
+  }
 }


### PR DESCRIPTION
Hi!
I'm submitting a new model integration as discussed.

### Changes
- Added `Unet2PixT1T2Model.py`: Implementation of a diffusion-based model (Unet2Pix) that generates a synthetic T2 slice from a T1 input.
- Updated `model_metadata.json`: Added entry for `unet2pix_t1_t2` pointing to the ONNX model hosted on GitHub.

### Model Details
- **Task:** MRI T1w -> MRI T2w.
- **Scope:** The model is designed to work on the **central axial slice** only (intended for research purposes on I2I translation).
- **Logic:** The inference logic copies the input volume, extracts the central slice, resizes it to 224x192 (model input size), runs inference via ONNX Runtime, resizes it back to original dimensions, and inserts it back into the volume.

**Note:**
I have implemented the logic and confirmed the model download, but due to hardware limitations, I couldn't run a full inference test in Slicer. I would appreciate it if you could verify the execution on your setup.

Looking forward to your feedback!